### PR TITLE
feat: adicionar result pattern e padronizar envelope de resposta REST

### DIFF
--- a/Exchange.API/Controllers/AuthenticationController.cs
+++ b/Exchange.API/Controllers/AuthenticationController.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.API.Extensions;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -25,7 +26,7 @@ namespace Exchange.API.Controllers
             };
 
             var response = await _authenticateClientUseCase.ExecuteAsync(request);
-            return Ok(response);
+            return this.ToActionResult(response);
         }
     }
 }

--- a/Exchange.API/Controllers/CurrencyController.cs
+++ b/Exchange.API/Controllers/CurrencyController.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.API.Extensions;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -31,7 +32,7 @@ namespace Exchange.API.Controllers
         public async Task<IActionResult> Convert([FromBody] ConvertCurrencyRequest request)
         {
             var result = await _convertCurrencyUseCase.ExecuteAsync(request);
-            return Ok(result);
+            return this.ToActionResult(result);
         }
 
         [HttpGet("history")]
@@ -45,33 +46,28 @@ namespace Exchange.API.Controllers
         {
             var request = new GetConversionHistoryRequest(fromCurrency, toCurrency, startDate, endDate, page, pageSize);
             var history = await _getConversionHistoryUseCase.ExecuteAsync(request);
-            return Ok(history);
+            return this.ToActionResult(history);
         }
 
         [HttpGet("history/{id:guid}")]
         public async Task<IActionResult> GetHistoryById(Guid id)
         {
             var item = await _getConversionHistoryUseCase.GetByIdAsync(id);
-            if (item is null)
-            {
-                return NotFound(new { error = "Conversão não encontrada." });
-            }
-
-            return Ok(item);
+            return this.ToActionResult(item);
         }
 
         [HttpGet("rate")]
         public async Task<IActionResult> GetRate([FromQuery] string currency, [FromQuery] DateOnly dateQuotation)
         {
             var result = await _getExchangeRateUseCase.ExecuteAsync(currency, dateQuotation);
-            return Ok(result);
+            return this.ToActionResult(result);
         }
 
         [HttpGet("supported")]
         public async Task<IActionResult> GetSupportedCurrencies()
         {
             var currencies = await _getSupportedCurrenciesUseCase.ExecuteAsync();
-            return Ok(new { currencies });
+            return this.ToActionResult(currencies);
         }
     }
 }

--- a/Exchange.API/Extensions/ResultExtensions.cs
+++ b/Exchange.API/Extensions/ResultExtensions.cs
@@ -1,0 +1,43 @@
+﻿using Exchange.API.Models;
+using Exchange.Application.Common;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Exchange.API.Extensions
+{
+    public static class ResultExtensions
+    {
+        public static IActionResult ToActionResult<T>(this ControllerBase controller, Result<T> result, object? meta = null)
+        {
+            if (result.IsSuccess)
+            {
+                return controller.Ok(new ApiResponse<T>
+                {
+                    Success = true,
+                    Data = result.Value,
+                    Error = null,
+                    Meta = meta
+                });
+            }
+
+            var statusCode = result.Error?.Code switch
+            {
+                "NOT_FOUND" => StatusCodes.Status404NotFound,
+                "UNAUTHORIZED" => StatusCodes.Status401Unauthorized,
+                "FORBIDDEN" => StatusCodes.Status403Forbidden,
+                "CONFLICT" => StatusCodes.Status409Conflict,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            return controller.StatusCode(statusCode, new ApiResponse<object>
+            {
+                Success = false,
+                Data = null,
+                Error = new ApiError(
+                    result.Error?.Code ?? "BAD_REQUEST",
+                    result.Error?.Message ?? "Não foi possível processar a requisição.",
+                    result.Error?.Details),
+                Meta = meta
+            });
+        }
+    }
+}

--- a/Exchange.API/Extensions/ResultExtensions.cs
+++ b/Exchange.API/Extensions/ResultExtensions.cs
@@ -6,7 +6,7 @@ namespace Exchange.API.Extensions
 {
     public static class ResultExtensions
     {
-        public static IActionResult ToActionResult<T>(this ControllerBase controller, Result<T> result, object? meta = null)
+        public static IActionResult ToActionResult<T>(this ControllerBase controller, Result<T> result)
         {
             if (result.IsSuccess)
             {
@@ -14,8 +14,7 @@ namespace Exchange.API.Extensions
                 {
                     Success = true,
                     Data = result.Value,
-                    Error = null,
-                    Meta = meta
+                    Error = null
                 });
             }
 
@@ -35,8 +34,7 @@ namespace Exchange.API.Extensions
                 Error = new ApiError(
                     result.Error?.Code ?? "BAD_REQUEST",
                     result.Error?.Message ?? "Não foi possível processar a requisição.",
-                    result.Error?.Details),
-                Meta = meta
+                    result.Error?.Details)
             });
         }
     }

--- a/Exchange.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Exchange.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -51,8 +51,7 @@ namespace Exchange.API.Middleware
             {
                 Success = false,
                 Data = null,
-                Error = new ApiError(code, message),
-                Meta = null
+                Error = new ApiError(code, message)
             });
 
             await context.Response.WriteAsync(result);

--- a/Exchange.API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/Exchange.API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using Exchange.API.Models;
+using System.Text.Json;
 
 namespace Exchange.API.Middleware
 {
@@ -22,31 +23,38 @@ namespace Exchange.API.Middleware
             catch (ArgumentException ex)
             {
                 _logger.LogWarning(ex, "ArgumentException capturada");
-                await WriteErrorAsync(httpContext, StatusCodes.Status400BadRequest, ex.Message);
+                await WriteErrorAsync(httpContext, StatusCodes.Status400BadRequest, "VALIDATION_ERROR", ex.Message);
             }
             catch (InvalidOperationException ex)
             {
                 _logger.LogWarning(ex, "InvalidOperationException capturada");
-                await WriteErrorAsync(httpContext, StatusCodes.Status400BadRequest, ex.Message);
+                await WriteErrorAsync(httpContext, StatusCodes.Status400BadRequest, "INVALID_OPERATION", ex.Message);
             }
             catch (UnauthorizedAccessException ex)
             {
                 _logger.LogWarning(ex, "UnauthorizedAccessException capturada");
-                await WriteErrorAsync(httpContext, StatusCodes.Status401Unauthorized, ex.Message);
+                await WriteErrorAsync(httpContext, StatusCodes.Status401Unauthorized, "UNAUTHORIZED", ex.Message);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Erro não tratado");
-                await WriteErrorAsync(httpContext, StatusCodes.Status500InternalServerError, "Ocorreu um erro inesperado.");
+                await WriteErrorAsync(httpContext, StatusCodes.Status500InternalServerError, "INTERNAL_ERROR", "Ocorreu um erro inesperado.");
             }
         }
 
-        private static async Task WriteErrorAsync(HttpContext context, int statusCode, string message)
+        private static async Task WriteErrorAsync(HttpContext context, int statusCode, string code, string message)
         {
             context.Response.StatusCode = statusCode;
             context.Response.ContentType = "application/json";
 
-            var result = JsonSerializer.Serialize(new { error = message });
+            var result = JsonSerializer.Serialize(new ApiResponse<object>
+            {
+                Success = false,
+                Data = null,
+                Error = new ApiError(code, message),
+                Meta = null
+            });
+
             await context.Response.WriteAsync(result);
         }
     }

--- a/Exchange.API/Models/ApiResponse.cs
+++ b/Exchange.API/Models/ApiResponse.cs
@@ -7,6 +7,5 @@
         public required bool Success { get; init; }
         public T? Data { get; init; }
         public ApiError? Error { get; init; }
-        public object? Meta { get; init; }
     }
 }

--- a/Exchange.API/Models/ApiResponse.cs
+++ b/Exchange.API/Models/ApiResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace Exchange.API.Models
+{
+    public sealed record ApiError(string Code, string Message, object? Details = null);
+
+    public sealed class ApiResponse<T>
+    {
+        public required bool Success { get; init; }
+        public T? Data { get; init; }
+        public ApiError? Error { get; init; }
+        public object? Meta { get; init; }
+    }
+}

--- a/Exchange.Application/Common/Result.cs
+++ b/Exchange.Application/Common/Result.cs
@@ -1,0 +1,34 @@
+namespace Exchange.Application.Common
+{
+    public class Result
+    {
+        protected Result(bool isSuccess, ResultError? error)
+        {
+            IsSuccess = isSuccess;
+            Error = error;
+        }
+
+        public bool IsSuccess { get; }
+        public bool IsFailure => !IsSuccess;
+        public ResultError? Error { get; }
+
+        public static Result Success() => new(true, null);
+
+        public static Result Failure(ResultError error) => new(false, error);
+    }
+
+    public sealed class Result<T> : Result
+    {
+        private Result(T? value, bool isSuccess, ResultError? error)
+            : base(isSuccess, error)
+        {
+            Value = value;
+        }
+
+        public T? Value { get; }
+
+        public static Result<T> Success(T value) => new(value, true, null);
+
+        public new static Result<T> Failure(ResultError error) => new(default, false, error);
+    }
+}

--- a/Exchange.Application/Common/ResultError.cs
+++ b/Exchange.Application/Common/ResultError.cs
@@ -1,0 +1,4 @@
+namespace Exchange.Application.Common
+{
+    public sealed record ResultError(string Code, string Message, object? Details = null);
+}

--- a/Exchange.Application/Interfaces/IAuthenticateClientUseCase.cs
+++ b/Exchange.Application/Interfaces/IAuthenticateClientUseCase.cs
@@ -1,10 +1,11 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 
 namespace Exchange.Application.Interfaces
 {
     public interface IAuthenticateClientUseCase
     {
-        Task<AuthResponse> ExecuteAsync(AuthRequest request);
+        Task<Result<AuthResponse>> ExecuteAsync(AuthRequest request);
     }
 }

--- a/Exchange.Application/Interfaces/IConvertCurrencyUseCase.cs
+++ b/Exchange.Application/Interfaces/IConvertCurrencyUseCase.cs
@@ -1,11 +1,11 @@
-﻿using Exchange.Application.Dtos.Requests;
+using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 
 namespace Exchange.Application.Interfaces
 {
     public interface IConvertCurrencyUseCase
     {
-        Task<ConvertCurrencyResponse> ExecuteAsync(ConvertCurrencyRequest request);
-
+        Task<Result<ConvertCurrencyResponse>> ExecuteAsync(ConvertCurrencyRequest request);
     }
 }

--- a/Exchange.Application/Interfaces/IGetConversionHistoryUseCase.cs
+++ b/Exchange.Application/Interfaces/IGetConversionHistoryUseCase.cs
@@ -1,11 +1,12 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 
 namespace Exchange.Application.Interfaces
 {
     public interface IGetConversionHistoryUseCase
     {
-        Task<PaginatedConversionHistoryResponse> ExecuteAsync(GetConversionHistoryRequest request);
-        Task<ConversionHistoryItemResponse?> GetByIdAsync(Guid id);
+        Task<Result<PaginatedConversionHistoryResponse>> ExecuteAsync(GetConversionHistoryRequest request);
+        Task<Result<ConversionHistoryItemResponse>> GetByIdAsync(Guid id);
     }
 }

--- a/Exchange.Application/Interfaces/IGetExchangeRateUseCase.cs
+++ b/Exchange.Application/Interfaces/IGetExchangeRateUseCase.cs
@@ -1,9 +1,10 @@
-﻿using Exchange.Application.Dtos.Responses;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Responses;
 
 namespace Exchange.Application.Interfaces
 {
     public interface IGetExchangeRateUseCase
     {
-        Task<ExchangeRateResponse> ExecuteAsync(string currency, DateOnly dateQuotation);
+        Task<Result<ExchangeRateResponse>> ExecuteAsync(string currency, DateOnly dateQuotation);
     }
 }

--- a/Exchange.Application/Interfaces/IGetSupportedCurrenciesUseCase.cs
+++ b/Exchange.Application/Interfaces/IGetSupportedCurrenciesUseCase.cs
@@ -1,9 +1,10 @@
-﻿using Exchange.Application.Dtos.Responses;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Responses;
 
 namespace Exchange.Application.Interfaces
 {
     public interface IGetSupportedCurrenciesUseCase
     {
-        Task<IReadOnlyCollection<SupportedCurrencyResponse>> ExecuteAsync();
+        Task<Result<IReadOnlyCollection<SupportedCurrencyResponse>>> ExecuteAsync();
     }
 }

--- a/Exchange.Application/UseCases/AuthenticateClient/AuthenticateClientUseCase.cs
+++ b/Exchange.Application/UseCases/AuthenticateClient/AuthenticateClientUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 using Exchange.Application.Interfaces;
 
@@ -13,11 +14,17 @@ namespace Exchange.Application.UseCases.AuthenticateClient
             _authenticationService = authenticationService;
         }
 
-        public Task<AuthResponse> ExecuteAsync(AuthRequest request)
+        public async Task<Result<AuthResponse>> ExecuteAsync(AuthRequest request)
         {
-            var response = _authenticationService.Authenticate(request);
-
-            return response;
+            try
+            {
+                var response = await _authenticationService.Authenticate(request);
+                return Result<AuthResponse>.Success(response);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Result<AuthResponse>.Failure(new ResultError("UNAUTHORIZED", ex.Message));
+            }
         }
     }
 }

--- a/Exchange.Application/UseCases/ConvertCurrency/ConvertCurrencyUseCase.cs
+++ b/Exchange.Application/UseCases/ConvertCurrency/ConvertCurrencyUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 using Exchange.Application.Interfaces;
 using Exchange.Domain.Entities;
@@ -20,10 +21,12 @@ namespace Exchange.Application.UseCases.ConvertCurrency
             _repository = repository;
         }
 
-        public async Task<ConvertCurrencyResponse> ExecuteAsync(ConvertCurrencyRequest request)
+        public async Task<Result<ConvertCurrencyResponse>> ExecuteAsync(ConvertCurrencyRequest request)
         {
             if (request.AmountBRL <= 0)
-                throw new ArgumentException("O valor deve ser maior que zero.");
+            {
+                return Result<ConvertCurrencyResponse>.Failure(new ResultError("VALIDATION_ERROR", "O valor deve ser maior que zero."));
+            }
 
             ExchangeRate exchangeRate = await _rateProvider.GetExchangeRateAsync(request.ToCurrency, request.DateQuotation);
 
@@ -46,7 +49,7 @@ namespace Exchange.Application.UseCases.ConvertCurrency
 
             await _repository.SaveAsync(record);
 
-            return new ConvertCurrencyResponse(
+            var response = new ConvertCurrencyResponse(
                 request.AmountBRL,
                 "BRL",
                 Math.Round(convertedAmount, 2),
@@ -56,6 +59,8 @@ namespace Exchange.Application.UseCases.ConvertCurrency
                 quotationDate,
                 ProviderName
             );
+
+            return Result<ConvertCurrencyResponse>.Success(response);
         }
 
         private static DateOnly TryResolveQuotationDate(string providerQuotationDate, DateOnly fallbackDate)

--- a/Exchange.Application/UseCases/GetConversionHistory/GetConversionHistoryUseCase.cs
+++ b/Exchange.Application/UseCases/GetConversionHistory/GetConversionHistoryUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Requests;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Requests;
 using Exchange.Application.Dtos.Responses;
 using Exchange.Application.Interfaces;
 using Exchange.Domain.Interfaces;
@@ -17,16 +18,16 @@ namespace Exchange.Application.UseCases.GetConversionHistory
             _memoryCache = memoryCache;
         }
 
-        public async Task<PaginatedConversionHistoryResponse> ExecuteAsync(GetConversionHistoryRequest request)
+        public async Task<Result<PaginatedConversionHistoryResponse>> ExecuteAsync(GetConversionHistoryRequest request)
         {
             if (request.Page <= 0)
             {
-                throw new ArgumentException("Page deve ser maior que zero.");
+                return Result<PaginatedConversionHistoryResponse>.Failure(new ResultError("VALIDATION_ERROR", "Page deve ser maior que zero."));
             }
 
             if (request.PageSize <= 0 || request.PageSize > 100)
             {
-                throw new ArgumentException("PageSize deve estar entre 1 e 100.");
+                return Result<PaginatedConversionHistoryResponse>.Failure(new ResultError("VALIDATION_ERROR", "PageSize deve estar entre 1 e 100."));
             }
 
             var normalizedFrom = NormalizeCurrency(request.FromCurrency);
@@ -36,7 +37,7 @@ namespace Exchange.Application.UseCases.GetConversionHistory
 
             if (_memoryCache.TryGetValue(cacheKey, out PaginatedConversionHistoryResponse? cachedHistory) && cachedHistory is not null)
             {
-                return cachedHistory;
+                return Result<PaginatedConversionHistoryResponse>.Success(cachedHistory);
             }
 
             var (items, totalCount) = await _repository.GetHistoryAsync(
@@ -55,13 +56,18 @@ namespace Exchange.Application.UseCases.GetConversionHistory
 
             _memoryCache.Set(cacheKey, response, TimeSpan.FromSeconds(60));
 
-            return response;
+            return Result<PaginatedConversionHistoryResponse>.Success(response);
         }
 
-        public async Task<ConversionHistoryItemResponse?> GetByIdAsync(Guid id)
+        public async Task<Result<ConversionHistoryItemResponse>> GetByIdAsync(Guid id)
         {
             var item = await _repository.GetByIdAsync(id);
-            return item is null ? null : MapToResponse(item);
+            if (item is null)
+            {
+                return Result<ConversionHistoryItemResponse>.Failure(new ResultError("NOT_FOUND", "Conversão não encontrada."));
+            }
+
+            return Result<ConversionHistoryItemResponse>.Success(MapToResponse(item));
         }
 
         private static string NormalizeCurrency(string? currency)

--- a/Exchange.Application/UseCases/GetExchangeRate/GetExchangeRateUseCase.cs
+++ b/Exchange.Application/UseCases/GetExchangeRate/GetExchangeRateUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Responses;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Responses;
 using Exchange.Application.Interfaces;
 using Exchange.Domain.Interfaces;
 
@@ -14,11 +15,11 @@ namespace Exchange.Application.UseCases.GetExchangeRate
             _exchangeRateProvider = exchangeRateProvider;
         }
 
-        public async Task<ExchangeRateResponse> ExecuteAsync(string currency, DateOnly dateQuotation)
+        public async Task<Result<ExchangeRateResponse>> ExecuteAsync(string currency, DateOnly dateQuotation)
         {
             if (string.IsNullOrWhiteSpace(currency))
             {
-                throw new ArgumentException("currency é obrigatório.");
+                return Result<ExchangeRateResponse>.Failure(new ResultError("VALIDATION_ERROR", "currency é obrigatório."));
             }
 
             var normalizedCurrency = currency.Trim().ToUpper();
@@ -27,7 +28,8 @@ namespace Exchange.Application.UseCases.GetExchangeRate
                 ? DateOnly.FromDateTime(parsed)
                 : dateQuotation;
 
-            return new ExchangeRateResponse(rate.Currency, rate.BuyRate, rate.SellRate, date, ProviderName);
+            var response = new ExchangeRateResponse(rate.Currency, rate.BuyRate, rate.SellRate, date, ProviderName);
+            return Result<ExchangeRateResponse>.Success(response);
         }
     }
 }

--- a/Exchange.Application/UseCases/GetSupportedCurrencies/GetSupportedCurrenciesUseCase.cs
+++ b/Exchange.Application/UseCases/GetSupportedCurrencies/GetSupportedCurrenciesUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Exchange.Application.Dtos.Responses;
+﻿using Exchange.Application.Common;
+using Exchange.Application.Dtos.Responses;
 using Exchange.Application.Interfaces;
 using Exchange.Domain.Interfaces;
 
@@ -13,13 +14,15 @@ namespace Exchange.Application.UseCases.GetSupportedCurrencies
             _exchangeRateProvider = exchangeRateProvider;
         }
 
-        public async Task<IReadOnlyCollection<SupportedCurrencyResponse>> ExecuteAsync()
+        public async Task<Result<IReadOnlyCollection<SupportedCurrencyResponse>>> ExecuteAsync()
         {
             var currencies = await _exchangeRateProvider.GetSupportedCurrenciesAsync();
 
-            return currencies
+            var response = currencies
                 .Select(c => new SupportedCurrencyResponse(c.Symbol, c.Name))
                 .ToList();
+
+            return Result<IReadOnlyCollection<SupportedCurrencyResponse>>.Success(response);
         }
     }
 }

--- a/Exchange.Unit.Tests/Application/UseCases/AuthenticateClientUseCaseTests.cs
+++ b/Exchange.Unit.Tests/Application/UseCases/AuthenticateClientUseCaseTests.cs
@@ -22,9 +22,26 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await useCase.ExecuteAsync(request);
 
-            Assert.Equal(expected.AccessToken, result.AccessToken);
-            Assert.Equal(expected.ExpiresAt, result.ExpiresAt);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(expected.AccessToken, result.Value!.AccessToken);
+            Assert.Equal(expected.ExpiresAt, result.Value.ExpiresAt);
             serviceMock.Verify(s => s.Authenticate(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ShouldReturnFailure_WhenCredentialsAreInvalid()
+        {
+            var serviceMock = new Mock<IAuthenticationService>();
+            var useCase = new AuthenticateClientUseCase(serviceMock.Object);
+            var request = new AuthRequest { ClientId = "client", ClientSecret = "secret" };
+
+            serviceMock.Setup(s => s.Authenticate(request))
+                .ThrowsAsync(new UnauthorizedAccessException("Credenciais inválidas."));
+
+            var result = await useCase.ExecuteAsync(request);
+
+            Assert.True(result.IsFailure);
+            Assert.Equal("UNAUTHORIZED", result.Error?.Code);
         }
     }
 }

--- a/Exchange.Unit.Tests/Application/UseCases/ConvertCurrencyUseCaseTests.cs
+++ b/Exchange.Unit.Tests/Application/UseCases/ConvertCurrencyUseCaseTests.cs
@@ -22,7 +22,7 @@ namespace Exchange.Unit.Tests.Application.UseCases
         }
 
         [Fact]
-        public async Task ExecuteAsync_ShouldThrowArgumentException_WhenAmountBRLIsZero()
+        public async Task ExecuteAsync_ShouldReturnFailure_WhenAmountBRLIsZero()
         {
             var request = new ConvertCurrencyRequest(
                 ToCurrency: "EUR",
@@ -31,7 +31,10 @@ namespace Exchange.Unit.Tests.Application.UseCases
                 ExchangeType: ExchangeQuotationEnum.Buy
             );
 
-            await Assert.ThrowsAsync<ArgumentException>(() => _useCase.ExecuteAsync(request));
+            var result = await _useCase.ExecuteAsync(request);
+
+            Assert.True(result.IsFailure);
+            Assert.Equal("VALIDATION_ERROR", result.Error?.Code);
         }
 
         [Fact]
@@ -50,16 +53,18 @@ namespace Exchange.Unit.Tests.Application.UseCases
                 .Setup(x => x.GetExchangeRateAsync(request.ToCurrency, request.DateQuotation))
                 .ReturnsAsync(exchangeRate);
 
-            var response = await _useCase.ExecuteAsync(request);
+            var result = await _useCase.ExecuteAsync(request);
 
-            Assert.Equal(1000m, response.OriginalAmount);
-            Assert.Equal("BRL", response.FromCurrency);
-            Assert.Equal("EUR", response.ToCurrency);
-            Assert.Equal(Math.Round(1000m / exchangeRate.BuyRate, 2), response.ConvertedAmount);
-            Assert.Equal(Math.Round(exchangeRate.BuyRate, 2), response.ExchangeRate);
-            Assert.Equal(ExchangeQuotationEnum.Buy, response.ExchangeType);
-            Assert.Equal("BACEN", response.Provider);
-            Assert.Equal(new DateOnly(2025, 8, 13), response.DateQuotation);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal(1000m, result.Value!.OriginalAmount);
+            Assert.Equal("BRL", result.Value.FromCurrency);
+            Assert.Equal("EUR", result.Value.ToCurrency);
+            Assert.Equal(Math.Round(1000m / exchangeRate.BuyRate, 2), result.Value.ConvertedAmount);
+            Assert.Equal(Math.Round(exchangeRate.BuyRate, 2), result.Value.ExchangeRate);
+            Assert.Equal(ExchangeQuotationEnum.Buy, result.Value.ExchangeType);
+            Assert.Equal("BACEN", result.Value.Provider);
+            Assert.Equal(new DateOnly(2025, 8, 13), result.Value.DateQuotation);
 
             _repositoryMock.Verify(r => r.SaveAsync(It.IsAny<ConversionRecord>()), Times.Once);
         }
@@ -80,11 +85,13 @@ namespace Exchange.Unit.Tests.Application.UseCases
                 .Setup(x => x.GetExchangeRateAsync(request.ToCurrency, request.DateQuotation))
                 .ReturnsAsync(exchangeRate);
 
-            var response = await _useCase.ExecuteAsync(request);
+            var result = await _useCase.ExecuteAsync(request);
 
-            Assert.Equal(Math.Round(1000m / exchangeRate.SellRate, 2), response.ConvertedAmount);
-            Assert.Equal(Math.Round(exchangeRate.SellRate, 2), response.ExchangeRate);
-            Assert.Equal(ExchangeQuotationEnum.Sell, response.ExchangeType);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal(Math.Round(1000m / exchangeRate.SellRate, 2), result.Value!.ConvertedAmount);
+            Assert.Equal(Math.Round(exchangeRate.SellRate, 2), result.Value.ExchangeRate);
+            Assert.Equal(ExchangeQuotationEnum.Sell, result.Value.ExchangeType);
 
             _repositoryMock.Verify(r => r.SaveAsync(It.IsAny<ConversionRecord>()), Times.Once);
         }
@@ -100,9 +107,10 @@ namespace Exchange.Unit.Tests.Application.UseCases
                 .Setup(x => x.GetExchangeRateAsync(request.ToCurrency, request.DateQuotation))
                 .ReturnsAsync(exchangeRate);
 
-            var response = await _useCase.ExecuteAsync(request);
+            var result = await _useCase.ExecuteAsync(request);
 
-            Assert.Equal(requestDate, response.DateQuotation);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(requestDate, result.Value!.DateQuotation);
         }
     }
 }

--- a/Exchange.Unit.Tests/Application/UseCases/GetConversionHistoryUseCaseTests.cs
+++ b/Exchange.Unit.Tests/Application/UseCases/GetConversionHistoryUseCaseTests.cs
@@ -30,9 +30,10 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null));
 
-            Assert.NotNull(result);
-            Assert.Empty(result.Items);
-            Assert.Equal(0, result.TotalCount);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Empty(result.Value!.Items);
+            Assert.Equal(0, result.Value.TotalCount);
         }
 
         [Fact]
@@ -49,25 +50,28 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null));
 
-            Assert.NotNull(result);
-            Assert.Equal(2, result.Items.Count());
-            Assert.Equal(2, result.TotalCount);
-            Assert.Contains(result.Items, r => r.ToCurrency == "EUR" && r.OriginalAmount == 1000m);
-            Assert.Contains(result.Items, r => r.ToCurrency == "USD" && r.OriginalAmount == 500m);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal(2, result.Value!.Items.Count());
+            Assert.Equal(2, result.Value.TotalCount);
+            Assert.Contains(result.Value.Items, r => r.ToCurrency == "EUR" && r.OriginalAmount == 1000m);
+            Assert.Contains(result.Value.Items, r => r.ToCurrency == "USD" && r.OriginalAmount == 500m);
         }
 
         [Fact]
-        public async Task ExecuteAsync_ShouldThrowArgumentException_WhenPageIsInvalid()
+        public async Task ExecuteAsync_ShouldReturnFailure_WhenPageIsInvalid()
         {
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null, 0, 20)));
+            var result = await _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null, 0, 20));
+            Assert.True(result.IsFailure);
+            Assert.Equal("VALIDATION_ERROR", result.Error?.Code);
         }
 
         [Fact]
-        public async Task ExecuteAsync_ShouldThrowArgumentException_WhenPageSizeIsInvalid()
+        public async Task ExecuteAsync_ShouldReturnFailure_WhenPageSizeIsInvalid()
         {
-            await Assert.ThrowsAsync<ArgumentException>(() =>
-                _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null, 1, 101)));
+            var result = await _useCase.ExecuteAsync(new GetConversionHistoryRequest(null, null, null, null, 1, 101));
+            Assert.True(result.IsFailure);
+            Assert.Equal("VALIDATION_ERROR", result.Error?.Code);
         }
 
         [Fact]
@@ -86,20 +90,23 @@ namespace Exchange.Unit.Tests.Application.UseCases
             var first = await _useCase.ExecuteAsync(request);
             var second = await _useCase.ExecuteAsync(request);
 
-            Assert.Single(first.Items);
-            Assert.Single(second.Items);
+            Assert.True(first.IsSuccess);
+            Assert.True(second.IsSuccess);
+            Assert.Single(first.Value!.Items);
+            Assert.Single(second.Value!.Items);
             _repositoryMock.Verify(r => r.GetHistoryAsync("BRL", "EUR", null, null, 1, 20), Times.Once);
         }
 
         [Fact]
-        public async Task GetByIdAsync_ShouldReturnNull_WhenItemDoesNotExist()
+        public async Task GetByIdAsync_ShouldReturnFailure_WhenItemDoesNotExist()
         {
             _repositoryMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>()))
                 .ReturnsAsync((ConversionRecord?)null);
 
             var result = await _useCase.GetByIdAsync(Guid.NewGuid());
 
-            Assert.Null(result);
+            Assert.True(result.IsFailure);
+            Assert.Equal("NOT_FOUND", result.Error?.Code);
         }
 
         [Fact]
@@ -113,10 +120,11 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await _useCase.GetByIdAsync(id);
 
-            Assert.NotNull(result);
-            Assert.Equal("USD", result!.ToCurrency);
-            Assert.Equal(ExchangeQuotationEnum.Sell, result.ExchangeType);
-            Assert.Equal("BACEN", result.Provider);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal("USD", result.Value!.ToCurrency);
+            Assert.Equal(ExchangeQuotationEnum.Sell, result.Value.ExchangeType);
+            Assert.Equal("BACEN", result.Value.Provider);
         }
     }
 }

--- a/Exchange.Unit.Tests/Application/UseCases/GetExchangeRateUseCaseTests.cs
+++ b/Exchange.Unit.Tests/Application/UseCases/GetExchangeRateUseCaseTests.cs
@@ -18,9 +18,11 @@ namespace Exchange.Unit.Tests.Application.UseCases
         }
 
         [Fact]
-        public async Task ExecuteAsync_ShouldThrowArgumentException_WhenCurrencyIsInvalid()
+        public async Task ExecuteAsync_ShouldReturnFailure_WhenCurrencyIsInvalid()
         {
-            await Assert.ThrowsAsync<ArgumentException>(() => _useCase.ExecuteAsync(" ", new DateOnly(2025, 8, 13)));
+            var result = await _useCase.ExecuteAsync(" ", new DateOnly(2025, 8, 13));
+            Assert.True(result.IsFailure);
+            Assert.Equal("VALIDATION_ERROR", result.Error?.Code);
         }
 
         [Fact]
@@ -35,11 +37,13 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await _useCase.ExecuteAsync(" eur ", dateQuotation);
 
-            Assert.Equal("EUR", result.Currency);
-            Assert.Equal(6.10m, result.BuyRate);
-            Assert.Equal(6.20m, result.SellRate);
-            Assert.Equal(new DateOnly(2025, 8, 13), result.DateQuotation);
-            Assert.Equal("BACEN", result.Provider);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal("EUR", result.Value!.Currency);
+            Assert.Equal(6.10m, result.Value.BuyRate);
+            Assert.Equal(6.20m, result.Value.SellRate);
+            Assert.Equal(new DateOnly(2025, 8, 13), result.Value.DateQuotation);
+            Assert.Equal("BACEN", result.Value.Provider);
         }
 
         [Fact]
@@ -54,7 +58,8 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await _useCase.ExecuteAsync("USD", dateQuotation);
 
-            Assert.Equal(dateQuotation, result.DateQuotation);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(dateQuotation, result.Value!.DateQuotation);
         }
     }
 }

--- a/Exchange.Unit.Tests/Application/UseCases/GetSupportedCurrenciesUseCaseTests.cs
+++ b/Exchange.Unit.Tests/Application/UseCases/GetSupportedCurrenciesUseCaseTests.cs
@@ -28,8 +28,10 @@ namespace Exchange.Unit.Tests.Application.UseCases
 
             var result = await useCase.ExecuteAsync();
 
-            Assert.Equal(3, result.Count);
-            Assert.Contains(result, x => x.Symbol == "USD" && x.Name == "Dólar dos EUA");
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Value);
+            Assert.Equal(3, result.Value!.Count);
+            Assert.Contains(result.Value, x => x.Symbol == "USD" && x.Name == "Dólar dos EUA");
             providerMock.Verify(p => p.GetSupportedCurrenciesAsync(), Times.Once);
         }
     }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,30 @@ Exchange.sln
 
 ## 📄 Exemplo de Requisição
 
+**POST** `/api/authentication/token`  
+**Headers:**
+
+```
+client_id: 3f29b6e7-1c4b-4f9a-b8b4-2f5e2f4d5c6a
+secret: f8d9a7b6-2c3e-4f7a-8b1d-3e2f4a5b6c7d
+```
+
+**Resposta esperada (resumo):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "accessToken": "jwt-token",
+    "expiresAt": "2026-03-07T15:00:00Z"
+  },
+  "error": null,
+  "meta": null
+}
+```
+
+---
+
 **POST** `/api/currency/convert`
 **Headers:**
 
@@ -105,11 +129,32 @@ Content-Type: application/json
 
 ```json
 {
+  "success": true,
+  "data": {
     "originalAmount": 1000,
     "fromCurrency": "BRL",
     "convertedAmount": 158.75,
     "toCurrency": "EUR",
-    "exchangeRate": 6.30
+    "exchangeRate": 6.30,
+    "exchangeType": 1,
+    "dateQuotation": "2025-08-13",
+    "provider": "BACEN"
+  },
+  "error": null,
+  "meta": null
+}
+```
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "O valor deve ser maior que zero.",
+    "details": null
+  },
+  "meta": null
 }
 ```
 
@@ -181,10 +226,11 @@ Exemplo: [Bacen - Exemplo de busca](https://olinda.bcb.gov.br/olinda/servico/PTA
 * [x] ✅ **Adicionar filtros e paginação no histórico** de conversões (DONE).
 * [x] ✅ **Ampliar cobertura de testes unitários** com relatório de cobertura (DONE).
 * [x] ✅ **buscar moedas suportadas dinamicamente no Bacen (DONE).
-* [ ] 🧩 **Adicionar result pattern ao projeto**
+* [x] ✅ **Adicionar result pattern ao projeto** (DONE)
+* [x] ✅ **Padronizar response envelope REST (`success/data/error/meta`)** (DONE)
 * [x] ☁️🚀 **Implantar na AWS**
 * [ ] ⏰ **Adicionar agendamento de conversões** com notificação quando taxa atingir determinado valor.
-* [ ] 🧪 **Adicionar Testes de integração** 
+* [ ] 🧪 **Adicionar testes de integração** 
 ### ***Indicadores de Conclusão***
  * [ ] = tarefa pendente.  
  * [x] = tarefa concluída

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ secret: f8d9a7b6-2c3e-4f7a-8b1d-3e2f4a5b6c7d
     "expiresAt": "2026-03-07T15:00:00Z"
   },
   "error": null,
-  "meta": null
 }
 ```
 
@@ -141,7 +140,6 @@ Content-Type: application/json
     "provider": "BACEN"
   },
   "error": null,
-  "meta": null
 }
 ```
 
@@ -154,7 +152,6 @@ Content-Type: application/json
     "message": "O valor deve ser maior que zero.",
     "details": null
   },
-  "meta": null
 }
 ```
 
@@ -227,7 +224,7 @@ Exemplo: [Bacen - Exemplo de busca](https://olinda.bcb.gov.br/olinda/servico/PTA
 * [x] ✅ **Ampliar cobertura de testes unitários** com relatório de cobertura (DONE).
 * [x] ✅ **buscar moedas suportadas dinamicamente no Bacen (DONE).
 * [x] ✅ **Adicionar result pattern ao projeto** (DONE)
-* [x] ✅ **Padronizar response envelope REST (`success/data/error/meta`)** (DONE)
+* [x] ✅ **Padronizar response envelope REST (`success/data/error`)** (DONE)
 * [x] ☁️🚀 **Implantar na AWS**
 * [ ] ⏰ **Adicionar agendamento de conversões** com notificação quando taxa atingir determinado valor.
 * [ ] 🧪 **Adicionar testes de integração** 
@@ -238,7 +235,3 @@ Exemplo: [Bacen - Exemplo de busca](https://olinda.bcb.gov.br/olinda/servico/PTA
 ---
 
 ### ✨ Made with ❤️ and ☕ by Diego Fernandes Lins ✨
-
-
-
-


### PR DESCRIPTION
## Contexto
Esta PR padroniza o fluxo de retorno da aplicação e o contrato HTTP da API, sem alteração de regra de negócio.

## Alterações
- Inclusão de Result, Result<T> e ResultError na camada de aplicação.
- Use cases e interfaces atualizados para retorno com Result<T>.
- Padronização de códigos de erro esperados (VALIDATION_ERROR, NOT_FOUND, UNAUTHORIZED).
- Padronização do envelope de resposta HTTP para success, data, error.
- Mapper centralizado para converter Result<T> em IActionResult.
- Controllers e middleware ajustados para o contrato padronizado.
- Testes unitários adaptados para o novo contrato.
- README atualizado com novos exemplos de requisição/resposta.

## Validação
- Executado: dotnet test Exchange.sln
- Resultado: 17 testes aprovados, 0 falhas.

## Observações
- Não houve alteração de regra de negócio.
- Houve alteração do contrato HTTP de resposta para envelope padronizado.
