### PR TITLE
infra: adicionar infraestrutura ECS via CloudFormation

### DIFF
--- a/.github/workflows/deploy-ecs-cloudformation.yml
+++ b/.github/workflows/deploy-ecs-cloudformation.yml
@@ -1,0 +1,83 @@
+name: deploy-ecs-cloudformation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-ecs-cloudformation-master
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configurar credenciais AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - name: Login no Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Definir URI da imagem
+        id: image
+        shell: bash
+        run: |
+          IMAGE_URI="${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${GITHUB_SHA}"
+          echo "uri=${IMAGE_URI}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build e push da imagem Docker
+        shell: bash
+        run: |
+          docker build -t "${{ steps.image.outputs.uri }}" -f Exchange.API/Dockerfile .
+          docker push "${{ steps.image.outputs.uri }}"
+
+      - name: Validar template CloudFormation
+        shell: bash
+        run: |
+          aws cloudformation validate-template \
+            --template-body file://Infra/cloudformation/ecs-fargate.yaml \
+            --region "${{ vars.AWS_REGION }}"
+
+      - name: Deploy da stack CloudFormation
+        shell: bash
+        run: |
+          aws cloudformation deploy \
+            --stack-name "${{ vars.CFN_STACK_NAME }}" \
+            --template-file Infra/cloudformation/ecs-fargate.yaml \
+            --parameter-overrides \
+              ProjectName="${{ vars.PROJECT_NAME }}" \
+              EnvironmentName="${{ vars.ENVIRONMENT_NAME }}" \
+              ContainerImage="${{ steps.image.outputs.uri }}" \
+              ContainerPort="${{ vars.CONTAINER_PORT }}" \
+              DesiredCount="${{ vars.DESIRED_COUNT }}" \
+              TaskCpu="${{ vars.TASK_CPU }}" \
+              TaskMemory="${{ vars.TASK_MEMORY }}" \
+              HealthCheckPath="${{ vars.HEALTH_CHECK_PATH }}" \
+              JwtIssuer="${{ vars.JWT_ISSUER }}" \
+              JwtAudience="${{ vars.JWT_AUDIENCE }}" \
+              JwtKey="${{ secrets.JWT_KEY }}" \
+              LogRetentionInDays="${{ vars.LOG_RETENTION_IN_DAYS }}" \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --region "${{ vars.AWS_REGION }}" \
+            --no-fail-on-empty-changeset
+
+      - name: Exibir outputs da stack
+        shell: bash
+        run: |
+          aws cloudformation describe-stacks \
+            --stack-name "${{ vars.CFN_STACK_NAME }}" \
+            --region "${{ vars.AWS_REGION }}" \
+            --query "Stacks[0].Outputs" \
+            --output table

--- a/Infra/README.md
+++ b/Infra/README.md
@@ -1,0 +1,59 @@
+# Infraestrutura como Codigo (AWS ECS + CloudFormation)
+
+Esta pasta contem o provisionamento de infraestrutura para publicar a API no AWS ECS (Fargate) com Application Load Balancer.
+
+## Estrutura
+
+- `cloudformation/ecs-fargate.yaml`: template principal do CloudFormation.
+- `cloudformation/parameters.dev.json`: exemplo de parametros para ambiente `dev`.
+- `scripts/deploy.ps1`: script para validar e aplicar stack.
+
+## Recursos provisionados
+
+- VPC com 2 subnets publicas em AZs diferentes
+- Internet Gateway e rota publica
+- Security Groups separados para ALB e ECS
+- Application Load Balancer com listener HTTP na porta 80
+- Target Group com health check em `/health`
+- ECS Cluster
+- Task Definition Fargate
+- ECS Service (1 task por padrao)
+- CloudWatch Log Group para logs do container
+- IAM Role de execucao da task e role da aplicacao
+
+## Pre-requisitos
+
+1. AWS CLI configurada com credenciais validas.
+2. Imagem Docker da API publicada no ECR.
+3. Ajustar o arquivo `parameters.dev.json` com a imagem real e JWT.
+
+## Como usar
+
+No diretorio raiz do projeto:
+
+```powershell
+.\Infra\scripts\deploy.ps1 -StackName exchange-api-dev -Region us-east-1
+```
+
+## Deploy sem script (opcional)
+
+```powershell
+aws cloudformation validate-template --template-body file://Infra/cloudformation/ecs-fargate.yaml --region us-east-1
+
+aws cloudformation deploy \
+  --stack-name exchange-api-dev \
+  --template-file Infra/cloudformation/ecs-fargate.yaml \
+  --parameter-overrides \
+    ProjectName=exchange-api \
+    EnvironmentName=dev \
+    ContainerImage=123456789012.dkr.ecr.us-east-1.amazonaws.com/exchange-api:latest \
+    JwtKey=<chave-jwt-segura> \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region us-east-1
+```
+
+## Observacoes
+
+- O template usa `AssignPublicIp: ENABLED` para simplificar ambientes de teste.
+- Para producao, o recomendado e migrar tasks para subnet privada com NAT Gateway e HTTPS (ACM + listener 443).
+- Este provisionamento nao altera regra de negocio da API.

--- a/Infra/cloudformation/ecs-fargate.yaml
+++ b/Infra/cloudformation/ecs-fargate.yaml
@@ -1,0 +1,320 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Stack para publicar Exchange.API no ECS Fargate com ALB.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: exchange-api
+    AllowedPattern: '^[a-z0-9-]+$'
+    Description: Prefixo para nomear recursos.
+
+  EnvironmentName:
+    Type: String
+    Default: dev
+    AllowedPattern: '^[a-z0-9-]+$'
+    Description: Ambiente de deploy (dev, hml, prod).
+
+  VpcCidr:
+    Type: String
+    Default: 10.20.0.0/16
+
+  PublicSubnet1Cidr:
+    Type: String
+    Default: 10.20.1.0/24
+
+  PublicSubnet2Cidr:
+    Type: String
+    Default: 10.20.2.0/24
+
+  ContainerImage:
+    Type: String
+    Description: URI da imagem no ECR (ex. 123456789012.dkr.ecr.us-east-1.amazonaws.com/exchange-api:latest).
+
+  ContainerPort:
+    Type: Number
+    Default: 8080
+
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  TaskCpu:
+    Type: Number
+    Default: 256
+    AllowedValues: [256, 512, 1024, 2048, 4096]
+
+  TaskMemory:
+    Type: Number
+    Default: 512
+    AllowedValues: [512, 1024, 2048, 3072, 4096, 5120, 6144, 7168, 8192]
+
+  HealthCheckPath:
+    Type: String
+    Default: /health
+
+  JwtIssuer:
+    Type: String
+    Default: exchange-api
+
+  JwtAudience:
+    Type: String
+    Default: exchange-api-clients
+
+  JwtKey:
+    Type: String
+    NoEcho: true
+    MinLength: 32
+    Description: Chave JWT para a API (minimo 32 caracteres).
+
+  LogRetentionInDays:
+    Type: Number
+    Default: 14
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365]
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-vpc'
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-igw'
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-public-rt'
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PublicSubnet1Cidr
+      AvailabilityZone: !Select [0, !GetAZs !Ref 'AWS::Region']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-public-a'
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Ref PublicSubnet2Cidr
+      AvailabilityZone: !Select [1, !GetAZs !Ref 'AWS::Region']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-public-b'
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet1
+
+  PublicSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet2
+
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Permite HTTP publico para o ALB.
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-alb-sg'
+
+  EcsServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Permite trafego do ALB para as tasks ECS.
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-${EnvironmentName}-ecs-sg'
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      Type: application
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      VpcId: !Ref VPC
+      TargetType: ip
+      HealthCheckPath: !Ref HealthCheckPath
+      Matcher:
+        HttpCode: 200-399
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  EcsCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub '${ProjectName}-${EnvironmentName}-cluster'
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/ecs/${ProjectName}-${EnvironmentName}'
+      RetentionInDays: !Ref LogRetentionInDays
+
+  EcsTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  EcsTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub '${ProjectName}-${EnvironmentName}-task'
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt EcsTaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt EcsTaskRole.Arn
+      ContainerDefinitions:
+        - Name: !Sub '${ProjectName}-${EnvironmentName}-container'
+          Image: !Ref ContainerImage
+          Essential: true
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+              Protocol: tcp
+          Environment:
+            - Name: ASPNETCORE_URLS
+              Value: !Sub 'http://0.0.0.0:${ContainerPort}'
+            - Name: Jwt__Issuer
+              Value: !Ref JwtIssuer
+            - Name: Jwt__Audience
+              Value: !Ref JwtAudience
+            - Name: Jwt__Key
+              Value: !Ref JwtKey
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: ecs
+
+  EcsService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - HttpListener
+    Properties:
+      Cluster: !Ref EcsCluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref EcsServiceSecurityGroup
+          Subnets:
+            - !Ref PublicSubnet1
+            - !Ref PublicSubnet2
+      LoadBalancers:
+        - TargetGroupArn: !Ref TargetGroup
+          ContainerName: !Sub '${ProjectName}-${EnvironmentName}-container'
+          ContainerPort: !Ref ContainerPort
+
+Outputs:
+  LoadBalancerDnsName:
+    Description: DNS publico do ALB.
+    Value: !GetAtt LoadBalancer.DNSName
+
+  ClusterName:
+    Description: Nome do cluster ECS.
+    Value: !Ref EcsCluster
+
+  ServiceName:
+    Description: Nome do service ECS.
+    Value: !Ref EcsService

--- a/Infra/cloudformation/ecs-fargate.yaml
+++ b/Infra/cloudformation/ecs-fargate.yaml
@@ -117,7 +117,9 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Ref PublicSubnet1Cidr
-      AvailabilityZone: !Select [0, !GetAZs !Ref 'AWS::Region']
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -128,7 +130,9 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Ref PublicSubnet2Cidr
-      AvailabilityZone: !Select [1, !GetAZs !Ref 'AWS::Region']
+      AvailabilityZone: !Select
+        - 1
+        - Fn::GetAZs: !Ref 'AWS::Region'
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name

--- a/Infra/cloudformation/parameters.dev.json
+++ b/Infra/cloudformation/parameters.dev.json
@@ -1,0 +1,46 @@
+[
+  {
+    "ParameterKey": "ProjectName",
+    "ParameterValue": "exchange-api"
+  },
+  {
+    "ParameterKey": "EnvironmentName",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "ContainerImage",
+    "ParameterValue": "123456789012.dkr.ecr.us-east-1.amazonaws.com/exchange-api:latest"
+  },
+  {
+    "ParameterKey": "ContainerPort",
+    "ParameterValue": "8080"
+  },
+  {
+    "ParameterKey": "DesiredCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "TaskCpu",
+    "ParameterValue": "256"
+  },
+  {
+    "ParameterKey": "TaskMemory",
+    "ParameterValue": "512"
+  },
+  {
+    "ParameterKey": "HealthCheckPath",
+    "ParameterValue": "/health"
+  },
+  {
+    "ParameterKey": "JwtIssuer",
+    "ParameterValue": "exchange-api"
+  },
+  {
+    "ParameterKey": "JwtAudience",
+    "ParameterValue": "exchange-api-clients"
+  },
+  {
+    "ParameterKey": "JwtKey",
+    "ParameterValue": "trocar-por-uma-chave-segura-com-mais-de-32-caracteres"
+  }
+]

--- a/Infra/scripts/deploy.ps1
+++ b/Infra/scripts/deploy.ps1
@@ -1,0 +1,49 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$StackName = "exchange-api-dev",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Region = "us-east-1",
+
+    [Parameter(Mandatory = $false)]
+    [string]$TemplateFile = ".\Infra\cloudformation\ecs-fargate.yaml",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ParametersFile = ".\Infra\cloudformation\parameters.dev.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+    throw "AWS CLI nao encontrada no PATH."
+}
+
+if (-not (Test-Path $TemplateFile)) {
+    throw "Template nao encontrado: $TemplateFile"
+}
+
+if (-not (Test-Path $ParametersFile)) {
+    throw "Arquivo de parametros nao encontrado: $ParametersFile"
+}
+
+Write-Host "Validando template CloudFormation..."
+aws cloudformation validate-template --template-body "file://$TemplateFile" --region $Region | Out-Null
+
+$parameters = Get-Content $ParametersFile -Raw | ConvertFrom-Json
+$parameterOverrides = @()
+
+foreach ($p in $parameters) {
+    $parameterOverrides += "$($p.ParameterKey)=$($p.ParameterValue)"
+}
+
+Write-Host "Criando/atualizando stack '$StackName' na regiao '$Region'..."
+aws cloudformation deploy `
+    --stack-name $StackName `
+    --template-file $TemplateFile `
+    --parameter-overrides $parameterOverrides `
+    --capabilities CAPABILITY_NAMED_IAM `
+    --region $Region
+
+Write-Host "Deploy finalizado."
+Write-Host "Recuperando outputs..."
+aws cloudformation describe-stacks --stack-name $StackName --region $Region --query "Stacks[0].Outputs" --output table

--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ Para testar a API, você pode usar os seguintes valores fixos para se autenticar
 
 A aplicação foi implantada com sucesso no **AWS ECS Fargate** e está disponível através do **ALB (Application Load Balancer)**.
 
+### Infraestrutura como código (CloudFormation)
+
+Foi adicionada a pasta `Infra/` na raiz do projeto com provisionamento via CloudFormation para ECS Fargate:
+
+- `Infra/cloudformation/ecs-fargate.yaml`: template principal de infraestrutura.
+- `Infra/cloudformation/parameters.dev.json`: parâmetros de exemplo para ambiente dev.
+- `Infra/scripts/deploy.ps1`: script para validar e aplicar stack.
+
+Comando de deploy:
+
+```powershell
+.\Infra\scripts\deploy.ps1 -StackName exchange-api-dev -Region us-east-1
+```
+
 ### 🌐 Endpoint
 Você pode acessar o endpoint de autenticação pelo link abaixo:
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Comando de deploy:
 .\Infra\scripts\deploy.ps1 -StackName exchange-api-dev -Region us-east-1
 ```
 
+Workflow de deploy no GitHub Actions:
+- Arquivo: `.github/workflows/deploy-ecs-cloudformation.yml`
+- Execucao manual via `workflow_dispatch` (nao executa automaticamente em push)
+
 ### 🌐 Endpoint
 Você pode acessar o endpoint de autenticação pelo link abaixo:
 
@@ -240,6 +244,7 @@ Exemplo: [Bacen - Exemplo de busca](https://olinda.bcb.gov.br/olinda/servico/PTA
 * [x] 🧩✅ **Adicionar Result Pattern ao projeto** (DONE).
 * [x] 📦✅ **Padronizar response envelope REST (`success/data/error`)** (DONE).
 * [x] ☁️🚀 **Implantar na AWS**
+* [x] ☁️🚀 **Criar Infraestrutura como codigo com CloudFormation**
 * [ ] ⏰ **Adicionar agendamento de conversões** com notificação quando taxa atingir determinado valor.
 * [ ] 🧪 **Adicionar testes de integração** 
 ### ***Indicadores de Conclusão***


### PR DESCRIPTION
﻿## Resumo
- Cria a pasta `Infra/` na raiz com infraestrutura como código para deploy no AWS ECS Fargate via CloudFormation.
- Adiciona template `Infra/cloudformation/ecs-fargate.yaml` com VPC, subnets públicas, ALB, target group, listener HTTP, ECS cluster, task definition, service, roles IAM e logs no CloudWatch.
- Adiciona `Infra/cloudformation/parameters.dev.json` com parâmetros de exemplo para ambiente dev.
- Adiciona `Infra/scripts/deploy.ps1` para validar e aplicar stack CloudFormation via AWS CLI.
- Adiciona workflow separado de deploy: `.github/workflows/deploy-ecs-cloudformation.yml`.
- Atualiza `README.md` com instruções de IaC e observação do deploy manual no GitHub Actions.
- Corrige sintaxe de `GetAZs` no CloudFormation para evitar erro de parsing no `validate-template`.

## Validação
- `dotnet build Exchange.sln` (sucesso)
- `dotnet test Exchange.sln --no-build` (sucesso: 17 testes aprovados)

## Observações
- Não houve alteração de regra de negócio da API.
- Workflow de deploy configurado para execução manual (`workflow_dispatch`), sem deploy automático em push.
